### PR TITLE
Fix system apps directory path for newer (API 21+) Android builds

### DIFF
--- a/bin/getclasses.pl
+++ b/bin/getclasses.pl
@@ -9,11 +9,22 @@ open FILE, "<$mydroid_dir$installed" or die $!;
 while (<FILE>) {
 	chomp($_);
 	if ($_ =~ m/  \/system\/app\/(.*).apk/) {
-		$sysapp = $1;
+		$sysapp = $1; # gets the system app directory path, ie "Calendar/Calendar"
 		if (-e "$mydroid_dir$sysapp_dir$sysapp"."_intermediates/classes-full-debug.jar") {
 			system("cp $mydroid_dir$sysapp_dir$sysapp"."_intermediates/classes-full-debug.jar $sysapp.jar");
+		} elsif (-e "$mydroid_dir$sysapp_dir$sysapp"."_intermediates/classes.jar") {
+			system("cp $mydroid_dir$sysapp_dir$sysapp"."_intermediates/classes.jar $sysapp.jar");
 		} else {
-			print "???Cannot find compiled classes for $sysapp???";
+			# newer Android builds removed the subdirectory, so trim the path
+			@fw_parts = split m%/%, $fw; # splits on /
+                	$fw = shift @fw_parts; # grabs first array element, ie "Calendar"
+			if (-e "$mydroid_dir$sysapp_dir$sysapp"."_intermediates/classes-full-debug.jar") {
+				system("cp $mydroid_dir$sysapp_dir$sysapp"."_intermediates/classes-full-debug.jar $sysapp.jar");
+			} elsif (-e "$mydroid_dir$sysapp_dir$sysapp"."_intermediates/classes.jar") {
+				system("cp $mydroid_dir$sysapp_dir$sysapp"."_intermediates/classes.jar $sysapp.jar");
+			} else {
+				print "???Cannot find compiled classes for $sysapp???\n";
+			}
 		}
 	} elsif ($_ =~ m/  \/system\/framework\/(.*).jar/) {
 		$fw = $1;


### PR DESCRIPTION
Android API 21+ seems to have changed the build directory structure for intermdiates slightly, running PScout on API 21 fails to find system apps so this fix adds a secondary directory check in case PScout is run over new builds, also added return line in println for consistent output formatting
